### PR TITLE
Fix unescaped ampersands

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
               <!-- Add your social/professional links -->
               <a href="https://www.linkedin.com/in/ibrahimkecoglu/" target="_blank" class="btn btn-outline-dark mx-2">LinkedIn</a>
               <a href="https://github.com/ikecoglu" target="_blank" class="btn btn-outline-dark mx-2">GitHub</a>
-              <a href="https://scholar.google.com/citations?user=ltzLUjEAAAAJ&hl=en&inst=5746887945952177237&oi=ao" target="_blank" class="btn btn-outline-dark mx-2">Google Scholar</a>
+              <a href="https://scholar.google.com/citations?user=ltzLUjEAAAAJ&amp;hl=en&amp;inst=5746887945952177237&amp;oi=ao" target="_blank" class="btn btn-outline-dark mx-2">Google Scholar</a>
             </div>
           </div>
         </div>
@@ -335,6 +335,6 @@
   <!-- Add Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   <!-- Add Google Font -->
-  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&amp;display=swap" rel="stylesheet">
 </body>
 </html>


### PR DESCRIPTION
## Summary
- escape ampersands in external URLs to silence HTML warnings

## Testing
- `tidy -e index.html`
- `python3 -m json.tool publications.json`

------
https://chatgpt.com/codex/tasks/task_e_6841d55070488323b6ce6001634503a3