### PR TITLE
Add Jest test for publication sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Testing Setup
+
+This project uses [Jest](https://jestjs.io/) for basic unit tests. To run the tests:
+
+1. Install dependencies once:
+
+   ```bash
+   npm install
+   ```
+
+2. Run the test suite:
+
+   ```bash
+   npm test
+   ```
+
+The test suite currently validates that the publication sorting logic orders entries from newest to oldest.

--- a/__tests__/sortPublications.test.js
+++ b/__tests__/sortPublications.test.js
@@ -1,0 +1,15 @@
+const { sortPublications } = require('../sortPublications');
+
+describe('sortPublications', () => {
+  test('orders publications from newest to oldest', () => {
+    const publications = [
+      { title: 'Old Paper', year: 2019 },
+      { title: 'New Paper', year: 2021 },
+      { title: 'Middle Paper', year: 2020 }
+    ];
+
+    const sorted = sortPublications([...publications]);
+
+    expect(sorted.map(p => p.title)).toEqual(['New Paper', 'Middle Paper', 'Old Paper']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ikecoglu-website-tests",
+  "version": "1.0.0",
+  "description": "Test suite for the website",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/sortPublications.js
+++ b/sortPublications.js
@@ -1,0 +1,9 @@
+function sortPublications(publications) {
+  return publications.sort((a, b) => {
+    const yearA = (a.issued && a.issued['date-parts'] && a.issued['date-parts'][0] && a.issued['date-parts'][0][0]) || a.year;
+    const yearB = (b.issued && b.issued['date-parts'] && b.issued['date-parts'][0] && b.issued['date-parts'][0][0]) || b.year;
+    return yearB - yearA;
+  });
+}
+
+module.exports = { sortPublications };


### PR DESCRIPTION
## Summary
- set up jest
- add helper to sort publications by year
- test sorting logic
- add instructions for running tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d7d4aa108323ba6ea7000f7869c7