### PR TITLE
Add Node.js CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run tests on push or PR to `main`

## Testing
- `npm ci --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68670ac604fc83238e49593bc3f70809